### PR TITLE
마진 관리 UI 초안 + 네비게이션 연결

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
 </project>

--- a/.idea/shelf/Uncommitted_changes_before_Checkout_at_2025-05-18__4_30__Changes_.xml
+++ b/.idea/shelf/Uncommitted_changes_before_Checkout_at_2025-05-18__4_30__Changes_.xml
@@ -1,0 +1,4 @@
+<changelist name="Uncommitted_changes_before_Checkout_at_2025-05-18_오후_4_30_[Changes]" date="1747553457971" recycled="true" deleted="true">
+  <option name="PATH" value="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Checkout_at_2025-05-18_오후_4_30_[Changes]/shelved.patch" />
+  <option name="DESCRIPTION" value="Uncommitted changes before Checkout at 2025-05-18 오후 4:30 [Changes]" />
+</changelist>

--- a/.idea/shelf/Uncommitted_changes_before_Checkout_at_2025-05-18_오후_4_30_[Changes]/shelved.patch
+++ b/.idea/shelf/Uncommitted_changes_before_Checkout_at_2025-05-18_오후_4_30_[Changes]/shelved.patch
@@ -1,0 +1,15 @@
+Index: .idea/misc.xml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.BaseRevisionTextPatchEP
+<+><?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<project version=\"4\">\r\n  <component name=\"ProjectRootManager\" version=\"2\" languageLevel=\"JDK_21\" default=\"true\" project-jdk-name=\"jbr-21\" project-jdk-type=\"JavaSDK\">\r\n    <output url=\"file://$PROJECT_DIR$/out\" />\r\n  </component>\r\n</project>
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/.idea/misc.xml b/.idea/misc.xml
+--- a/.idea/misc.xml	(revision 520abc73e16770d928ce80b65922995dfb8bbd1d)
++++ b/.idea/misc.xml	(date 1747553447642)
+@@ -1,4 +1,3 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+ <project version="4">
+   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+     <output url="file://$PROJECT_DIR$/out" />

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/FoodCostScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/FoodCostScreen.kt
@@ -1,225 +1,23 @@
 package com.glowstudio.android.blindsjn.feature.foodcost
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.border
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.background
-
-data class Recipe(
-    val name: String,
-    val price: Int,
-    val ingredientCost: Int,
-    val margin: Int
-)
+import androidx.compose.runtime.Composable
+import com.glowstudio.android.blindsjn.feature.foodcost.view.MarginListScreen
 
 @Composable
 fun FoodCostScreen(
-    onRegisterRecipeClick: () -> Unit,
-    onRegisterIngredientClick: () -> Unit,
+    onRecipeListClick: () -> Unit = {},
+    onRegisterRecipeClick: () -> Unit = {},
+    onIngredientListClick: () -> Unit = {},
+    onRegisterIngredientClick: () -> Unit = {},
     onNavigateToPayManagement: () -> Unit = {},
     onNavigateToFoodCost: () -> Unit = {},
 ) {
-    var recipes by remember { mutableStateOf(listOf(
-        Recipe("김치찌개", 8000, 3000, 5000),
-        Recipe("된장국", 7000, 2500, 4500),
-        Recipe("비빔밥", 9000, 3500, 5500),
-        Recipe("순대국", 8500, 3200, 5300),
-        Recipe("갈비탕", 12000, 5000, 7000),
-        Recipe("삼겹살", 15000, 7000, 8000),
-        Recipe("닭갈비", 13000, 5500, 7500),
-        Recipe("부대찌개", 11000, 4500, 6500),
-        Recipe("떡볶이", 6000, 2000, 4000),
-        Recipe("라면", 5000, 1500, 3500),
-        Recipe("김밥", 4500, 1200, 3300),
-        Recipe("튀김", 7000, 2500, 4500)
-    )) }
-    
-    var sortField by remember { mutableStateOf("name") }
-    var isAscending by remember { mutableStateOf(false) }
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        // 매출관리/마진관리 버튼
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(48.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(MaterialTheme.colorScheme.surface)
-                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
-                    .clickable { onNavigateToPayManagement() },
-                contentAlignment = Alignment.Center
-            ) {
-                Text("매출관리", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold, fontSize = 20.sp)
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .height(48.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(MaterialTheme.colorScheme.primary)
-                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
-                    .clickable { onNavigateToFoodCost() },
-                contentAlignment = Alignment.Center
-            ) {
-                Text("마진관리", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold, fontSize = 20.sp)
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        // Recipe List Header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            SortableHeader("레시피 이름", "name", sortField, isAscending) { field, ascending ->
-                sortField = field
-                isAscending = ascending
-                recipes = sortRecipes(recipes, field, ascending)
-            }
-            SortableHeader("레시피 가격", "price", sortField, isAscending) { field, ascending ->
-                sortField = field
-                isAscending = ascending
-                recipes = sortRecipes(recipes, field, ascending)
-            }
-            SortableHeader("재료 가격", "ingredientCost", sortField, isAscending) { field, ascending ->
-                sortField = field
-                isAscending = ascending
-                recipes = sortRecipes(recipes, field, ascending)
-            }
-            SortableHeader("마진", "margin", sortField, isAscending) { field, ascending ->
-                sortField = field
-                isAscending = ascending
-                recipes = sortRecipes(recipes, field, ascending)
-            }
-        }
-
-        // Recipe List
-        LazyColumn(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            items(recipes) { recipe ->
-                RecipeItem(recipe)
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Registration Buttons
-        Button(
-            onClick = onRegisterRecipeClick,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("레시피 등록")
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Button(
-            onClick = onRegisterIngredientClick,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("재료 등록")
-        }
-    }
-}
-
-@Composable
-fun SortableHeader(
-    title: String,
-    field: String,
-    currentSortField: String,
-    isAscending: Boolean,
-    onSort: (String, Boolean) -> Unit
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clickable {
-            onSort(field, if (currentSortField == field) !isAscending else false)
-        }
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyMedium,
-            fontSize = 16.sp,
-            fontWeight = if (currentSortField == field) FontWeight.Bold else FontWeight.Normal
-        )
-        if (currentSortField == field) {
-            Icon(
-                imageVector = if (isAscending) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                contentDescription = if (isAscending) "오름차순" else "내림차순",
-                modifier = Modifier.size(16.dp)
-            )
-        }
-    }
-}
-
-@Composable
-fun RecipeItem(recipe: Recipe) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(
-            text = recipe.name,
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium,
-            fontSize = 16.sp
-        )
-        Text(
-            text = "${recipe.price}원",
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium,
-            fontSize = 16.sp
-        )
-        Text(
-            text = "${recipe.ingredientCost}원",
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium,
-            fontSize = 16.sp
-        )
-        Text(
-            text = "${recipe.margin}원",
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyMedium,
-            fontSize = 16.sp
-        )
-    }
-}
-
-private fun sortRecipes(recipes: List<Recipe>, field: String, ascending: Boolean): List<Recipe> {
-    return when (field) {
-        "name" -> recipes.sortedBy { it.name }.let { if (ascending) it else it.reversed() }
-        "price" -> recipes.sortedBy { it.price }.let { if (ascending) it else it.reversed() }
-        "ingredientCost" -> recipes.sortedBy { it.ingredientCost }.let { if (ascending) it else it.reversed() }
-        "margin" -> recipes.sortedBy { it.margin }.let { if (ascending) it else it.reversed() }
-        else -> recipes
-    }
+    MarginListScreen(
+        onRecipeListClick = onRecipeListClick,
+        onRegisterRecipeClick = onRegisterRecipeClick,
+        onIngredientListClick = onIngredientListClick,
+        onRegisterIngredientClick = onRegisterIngredientClick,
+        onNavigateToPayManagement = onNavigateToPayManagement,
+        onNavigateToMargin = onNavigateToFoodCost
+    )
 }

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/EditRecipeScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/EditRecipeScreen.kt
@@ -1,0 +1,73 @@
+package com.glowstudio.android.blindsjn.feature.foodcost.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glowstudio.android.blindsjn.ui.theme.*
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun EditRecipeScreen(
+    recipeName: String = "빵",
+    onEditIngredientClick: (String) -> Unit = {},
+    onSaveClick: () -> Unit = {}
+) {
+    val ingredients = remember {
+        listOf("밀가루" to 1000, "물" to 600)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundWhite)
+            .padding(16.dp)
+    ) {
+        Text(recipeName, fontWeight = FontWeight.Bold, fontSize = 28.sp, color = TextPrimary)
+        Spacer(Modifier.height(16.dp))
+        Row(
+            Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("재료 이름", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Text("단위(g)", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Spacer(Modifier.width(48.dp))
+        }
+        Divider(color = DividerGray, thickness = 1.dp)
+        Spacer(Modifier.height(8.dp))
+        ingredients.forEach { (name, gram) ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .background(CardWhite, RoundedCornerShape(8.dp))
+                    .padding(vertical = 8.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(name, Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                Text("$gram", Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                TextButton(onClick = { onEditIngredientClick(name) }) {
+                    Text("수정", color = Blue, fontWeight = FontWeight.Bold)
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+        }
+        Spacer(Modifier.weight(1f))
+        Button(
+            onClick = onSaveClick,
+            colors = ButtonDefaults.buttonColors(containerColor = Blue, contentColor = Color.White),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth().height(48.dp)
+        ) {
+            Text("수정", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        }
+    }
+} 

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/IngredientListScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/IngredientListScreen.kt
@@ -1,0 +1,78 @@
+package com.glowstudio.android.blindsjn.feature.foodcost.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glowstudio.android.blindsjn.ui.theme.*
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun IngredientListScreen(
+    onEditIngredientClick: (String) -> Unit = {},
+    onRegisterIngredientClick: () -> Unit = {}
+) {
+    val ingredients = remember {
+        listOf("밀가루" to 1000, "물" to 600)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundWhite)
+            .padding(16.dp)
+    ) {
+        Text("재료 리스트", fontWeight = FontWeight.Bold, fontSize = 28.sp, color = TextPrimary)
+        Spacer(Modifier.height(16.dp))
+        Row(
+            Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("이름", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Text("단위(g)", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Spacer(Modifier.width(48.dp))
+        }
+        Divider(color = DividerGray, thickness = 1.dp)
+        Spacer(Modifier.height(8.dp))
+        ingredients.forEach { (name, gram) ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .background(CardWhite, RoundedCornerShape(8.dp))
+                    .padding(vertical = 8.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(name, Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                Text("$gram", Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                TextButton(onClick = { onEditIngredientClick(name) }) {
+                    Text("수정", color = Blue, fontWeight = FontWeight.Bold)
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+        }
+        Spacer(Modifier.weight(1f))
+        Button(
+            onClick = onRegisterIngredientClick,
+            colors = ButtonDefaults.buttonColors(containerColor = Blue, contentColor = Color.White),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth().height(48.dp)
+        ) {
+            Text("재료 등록", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun IngredientListScreenPreview() {
+    IngredientListScreen()
+} 

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/MarginListScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/MarginListScreen.kt
@@ -1,0 +1,192 @@
+package com.glowstudio.android.blindsjn.feature.foodcost.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glowstudio.android.blindsjn.ui.theme.*
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun MarginListScreen(
+    onRecipeListClick: () -> Unit = {},
+    onRegisterRecipeClick: () -> Unit = {},
+    onIngredientListClick: () -> Unit = {},
+    onRegisterIngredientClick: () -> Unit = {},
+    onNavigateToPayManagement: () -> Unit = {},
+    onNavigateToMargin: () -> Unit = {},
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundWhite)
+            .padding(16.dp)
+    ) {
+        // 상단 탭
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            TabButton(text = "매출관리", selected = false, onClick = onNavigateToPayManagement, modifier = Modifier.weight(1f))
+            TabButton(text = "마진관리", selected = true, onClick = onNavigateToMargin, modifier = Modifier.weight(1f))
+        }
+        Spacer(Modifier.height(16.dp))
+        // 표 헤더
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(CardWhite, RoundedCornerShape(4.dp))
+                .padding(vertical = 8.dp, horizontal = 8.dp),
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Text("이름", modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
+            Text("판매가", modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
+            Text("원가", modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
+            Text("마진", modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
+            Text("마진율", modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
+        }
+        // 표 리스트
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .border(2.dp, Blue, RoundedCornerShape(4.dp))
+                .background(Color.White)
+        ) {
+            Column(Modifier.fillMaxSize()) {
+                // 예시 데이터
+                val items = listOf(
+                    MarginItem("빵", 5000, 3600, 1400, 24),
+                    MarginItem("떡볶이", 6000, 4000, 2000, 33),
+                    MarginItem("김밥", 4500, 3000, 1500, 33)
+                )
+                items.forEach { item ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .background(CardWhite, RoundedCornerShape(2.dp))
+                            .padding(vertical = 6.dp, horizontal = 8.dp),
+                        horizontalArrangement = Arrangement.Start
+                    ) {
+                        Text(item.name, modifier = Modifier.weight(1f))
+                        Text("${item.price}원", modifier = Modifier.weight(1f))
+                        Text("${item.cost}원", modifier = Modifier.weight(1f))
+                        Text("${item.margin}원", modifier = Modifier.weight(1f))
+                        Text("${item.marginRate}%", modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(24.dp))
+        // 하단 버튼들
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                MainButton("레시피 리스트", onRecipeListClick)
+                Spacer(Modifier.height(12.dp))
+                MainButton("재료 리스트", onIngredientListClick)
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                MainButton("레시피 등록", onRegisterRecipeClick)
+                Spacer(Modifier.height(12.dp))
+                MainButton("재료 등록", onRegisterIngredientClick)
+            }
+        }
+    }
+}
+
+@Composable
+fun TabButton(text: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = if (selected) Blue else Color.White,
+            contentColor = if (selected) Color.White else Blue
+        ),
+        shape = RoundedCornerShape(16.dp),
+        modifier = modifier
+    ) {
+        Text(text, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+    }
+}
+
+@Composable
+fun ChartTabButton(text: String, selected: Boolean) {
+    Box(
+        Modifier
+            .padding(end = 8.dp)
+            .background(if (selected) Blue else Color.White, RoundedCornerShape(8.dp))
+            .border(1.dp, Blue, RoundedCornerShape(8.dp))
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+    ) {
+        Text(text, color = if (selected) Color.White else Blue, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+fun BarChartBar(label: String, percent: Float, value: Int) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            Modifier
+                .width(32.dp)
+                .height((100 * percent).dp)
+                .background(Blue, RoundedCornerShape(8.dp))
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(label, color = TextSecondary, fontSize = 14.sp)
+        Text("$value", color = TextSecondary, fontSize = 14.sp)
+    }
+}
+
+@Composable
+fun PieChart(percent1: Float, percent2: Float) {
+    // 실제 파이차트 대신 원형 Box 2개로 대체 (예시)
+    Box(Modifier.size(80.dp), contentAlignment = Alignment.Center) {
+        Box(
+            Modifier
+                .size(80.dp)
+                .background(LightBlue, shape = RoundedCornerShape(40.dp))
+        )
+        Box(
+            Modifier
+                .size(80.dp * percent1)
+                .background(Blue, shape = RoundedCornerShape(40.dp))
+        )
+    }
+}
+
+@Composable
+fun MainButton(text: String, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(containerColor = Blue, contentColor = Color.White),
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxWidth().height(48.dp)
+    ) {
+        Text(text, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+    }
+}
+
+data class MarginItem(
+    val name: String,
+    val price: Int,
+    val cost: Int,
+    val margin: Int,
+    val marginRate: Int
+)
+
+@Preview(showBackground = true)
+@Composable
+fun MarginListScreenPreview() {
+    MarginListScreen()
+} 

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/RecipeListScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/foodcost/view/RecipeListScreen.kt
@@ -1,0 +1,79 @@
+package com.glowstudio.android.blindsjn.feature.foodcost.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.glowstudio.android.blindsjn.ui.theme.*
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun RecipeListScreen(
+    onEditRecipeClick: (String) -> Unit = {},
+    onRegisterRecipeClick: () -> Unit = {}
+) {
+    val recipes = remember {
+        listOf("빵" to 5000, "떡볶이" to 6000, "김밥" to 4500)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BackgroundWhite)
+            .padding(16.dp)
+    ) {
+        Text("레시피", fontWeight = FontWeight.Bold, fontSize = 28.sp, color = TextPrimary)
+        Spacer(Modifier.height(16.dp))
+        Row(
+            Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("이름", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Text("판매가", fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+            Spacer(Modifier.width(48.dp))
+        }
+        Divider(color = DividerGray, thickness = 1.dp)
+        Spacer(Modifier.height(8.dp))
+        recipes.forEach { (name, price) ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .background(CardWhite, RoundedCornerShape(8.dp))
+                    .padding(vertical = 8.dp, horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(name, Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                Text("$price", Modifier.weight(1f), fontSize = 16.sp, color = TextPrimary)
+                TextButton(onClick = { onEditRecipeClick(name) }) {
+                    Text("수정", color = Blue, fontWeight = FontWeight.Bold)
+                }
+            }
+            Spacer(Modifier.height(4.dp))
+        }
+        Spacer(Modifier.weight(1f))
+        Button(
+            onClick = onRegisterRecipeClick,
+            colors = ButtonDefaults.buttonColors(containerColor = Blue, contentColor = Color.White),
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier.fillMaxWidth().height(48.dp)
+        ) {
+            Text("레시피 등록", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RecipeListScreenPreview() {
+    RecipeListScreen()
+} 

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/main/view/BottomNavigationBar.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/main/view/BottomNavigationBar.kt
@@ -37,7 +37,8 @@ fun BottomNavigationBar(
                 label = { Text(screen.title) },
                 selected = navController.currentBackStackEntry?.destination?.route == screen.route,
                 onClick = {
-                    navController.navigate(screen.route) {
+                    val targetRoute = if (screen is Screen.Popular) "foodcoast" else screen.route
+                    navController.navigate(targetRoute) {
                         popUpTo(navController.graph.findStartDestination().id) {
                             saveState = true
                         }

--- a/app/src/main/java/com/glowstudio/android/blindsjn/feature/main/view/MainScreen.kt
+++ b/app/src/main/java/com/glowstudio/android/blindsjn/feature/main/view/MainScreen.kt
@@ -44,6 +44,9 @@ import com.glowstudio.android.blindsjn.feature.paymanagement.PayManagementScreen
 import com.glowstudio.android.blindsjn.feature.foodcost.FoodCostScreen
 import com.glowstudio.android.blindsjn.feature.foodcost.RegisterRecipeScreen
 import com.glowstudio.android.blindsjn.feature.foodcost.RegisterIngredientScreen
+import com.glowstudio.android.blindsjn.feature.foodcost.view.RecipeListScreen
+import com.glowstudio.android.blindsjn.feature.foodcost.view.EditRecipeScreen
+import com.glowstudio.android.blindsjn.feature.foodcost.view.IngredientListScreen
 
 /**
  * 메인 스크린: 상단바, 하단 네비게이션 바, 내부 컨텐츠(AppNavHost)를 포함하여 전체 화면 전환을 관리합니다.
@@ -93,12 +96,36 @@ fun MainScreen(
                         onProfileEditClick = { /* ... */ },
                         onContactEditClick = { /* ... */ }
                     ) }
-                    composable("foodcoast") { FoodCostScreen(
-                        onRegisterRecipeClick = { navController.navigate("registerRecipe") },
-                        onRegisterIngredientClick = { navController.navigate("registerIngredient") },
-                        onNavigateToPayManagement = { navController.navigate("paymanagement") },
-                        onNavigateToFoodCost = { navController.navigate("foodcoast") }
-                    ) }
+                    composable("foodcoast") {
+                        FoodCostScreen(
+                            onRecipeListClick = { navController.navigate("recipeList") },
+                            onRegisterRecipeClick = { navController.navigate("registerRecipe") },
+                            onIngredientListClick = { navController.navigate("ingredientList") },
+                            onRegisterIngredientClick = { navController.navigate("registerIngredient") },
+                            onNavigateToPayManagement = { navController.navigate("paymanagement") },
+                            onNavigateToFoodCost = { navController.navigate("foodcoast") }
+                        )
+                    }
+                    composable("recipeList") {
+                        RecipeListScreen(
+                            onEditRecipeClick = { recipeName -> navController.navigate("editRecipe/$recipeName") },
+                            onRegisterRecipeClick = { navController.navigate("registerRecipe") }
+                        )
+                    }
+                    composable("editRecipe/{recipeName}") { backStackEntry ->
+                        val recipeName = backStackEntry.arguments?.getString("recipeName") ?: ""
+                        EditRecipeScreen(
+                            recipeName = recipeName,
+                            onEditIngredientClick = { /* TODO: 재료 수정 화면으로 이동 */ },
+                            onSaveClick = { navController.popBackStack() }
+                        )
+                    }
+                    composable("ingredientList") {
+                        IngredientListScreen(
+                            onEditIngredientClick = { /* TODO: 재료 수정 화면으로 이동 */ },
+                            onRegisterIngredientClick = { navController.navigate("registerIngredient") }
+                        )
+                    }
                     composable("registerIngredient") { RegisterIngredientScreen() }
                     composable("registerRecipe") { RegisterRecipeScreen() }
                     composable("boardDetail/{title}") { backStackEntry ->


### PR DESCRIPTION
마진 관리 UI 초안 + 네비게이션 연결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 마진 관리, 레시피 리스트, 재료 리스트, 레시피/재료 등록 및 수정 등 식자재 원가 관리 관련 신규 화면이 추가되었습니다.
    - 레시피 및 재료 리스트에서 각 항목을 수정하거나 새로 등록할 수 있는 버튼이 제공됩니다.
    - 마진 관리 화면에서 매출/마진 탭 전환 및 관련 데이터 테이블, 액션 버튼 UI가 제공됩니다.
- **기능 개선**
    - 기존 FoodCostScreen이 MarginListScreen을 사용하도록 단순화되었습니다.
    - 메인 화면에서 식자재 원가 관리 관련 신규 화면으로의 네비게이션 경로가 추가되었습니다.
    - 하단 네비게이션 바에서 특정 탭 선택 시 식자재 원가 관리 화면으로 이동하도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->